### PR TITLE
Correct package name for debian (snmp->snmpd)

### DIFF
--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -16,7 +16,7 @@
         'trapdargs': '-Lsd -p /var/run/snmptrapd.pid',
     },
     'Debian': {
-        'pkg': 'snmp',
+        'pkg': 'snmpd',
         'pkgutils': 'snmp-utils',
         'service': 'snmpd',
         'servicetrap': 'snmptrapd',


### PR DESCRIPTION
Package name for debian was wrong.
snmp provides applications, not the daemon.