### PR TITLE
auth- and priv protocol for snmpv3 users can now be changed

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -18,10 +18,14 @@ snmp:
       - username: 'myv3user'
         passphrase: 'myv3password'
         view: '.1'
+        # authproto: 'SHA'
+        # privproto: 'AES'
     rwusers:
       - username: 'myv3user_rw'
         passphrase: 'myv3password'
         view: '.1'
+        # authproto: 'SHA'
+        # privproto: 'AES'
     settings:
       # agentAddress: 'udp:161,udp6:[::1]:161'
       sysServices: 72

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -491,17 +491,17 @@ dontLogTCPWrappersConnects yes
 
 # Version 3 users
 
-{%- for user in salt['pillar.get']('snmp:conf:rousers', '') -%}
+{%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
 rouser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor -%}
+{%- endfor %}
 
-{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') -%}
+{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor -%}
+{%- endfor %}
 
 {% for declaration, values in config.items() %}
 {%- if values.__class__ in (().__class__, [].__class__) %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -491,17 +491,17 @@ dontLogTCPWrappersConnects yes
 
 # Version 3 users
 
-{% for user in salt['pillar.get']('snmp:conf:rousers', '') %}
+{%- for user in salt['pillar.get']('snmp:conf:rousers', '') -%}
 rouser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{% endfor %}
+{%- endfor -%}
 
-{% for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
+{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') -%}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{% endfor %}
+{%- endfor -%}
 
 {% for declaration, values in config.items() %}
 {%- if values.__class__ in (().__class__, [].__class__) %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -493,13 +493,13 @@ dontLogTCPWrappersConnects yes
 
 {% for user in salt['pillar.get']('snmp:conf:rousers', '') %}
 rouser {{ user.username }} auth -V {{ user.username }}_view
-createUser {{ user.username }} MD5 {{ user.passphrase }} AES
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
 {% endfor %}
 
 {% for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
-createUser {{ user.username }} MD5 {{ user.passphrase }} AES
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
 {% endfor %}
 

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -46,17 +46,17 @@ rwcommunity	{{ rwcommunity }}	{{ source }}
 {%- endfor %}
 
 # Version 3 users (read only)
-{% for user in salt['pillar.get']('snmp:conf:rousers', '') %}
+{%- for user in salt['pillar.get']('snmp:conf:rousers', '') -%}
 rouser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor %}
+{%- endfor -%}
 # Version 3 users (read/write)
-{% for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
+{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') -%}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor %}
+{%- endfor -%}
 
 # Extra settings
 {% for declaration, values in config.items() %}

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -46,17 +46,17 @@ rwcommunity	{{ rwcommunity }}	{{ source }}
 {%- endfor %}
 
 # Version 3 users (read only)
-{%- for user in salt['pillar.get']('snmp:conf:rousers', '') -%}
+{%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
 rouser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor -%}
+{%- endfor %}
 # Version 3 users (read/write)
-{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') -%}
+{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
-{%- endfor -%}
+{%- endfor %}
 
 # Extra settings
 {% for declaration, values in config.items() %}

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -48,13 +48,13 @@ rwcommunity	{{ rwcommunity }}	{{ source }}
 # Version 3 users (read only)
 {% for user in salt['pillar.get']('snmp:conf:rousers', '') %}
 rouser {{ user.username }} auth -V {{ user.username }}_view
-createUser {{ user.username }} MD5 {{ user.passphrase }} AES
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
 {%- endfor %}
 # Version 3 users (read/write)
 {% for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
 rwuser {{ user.username }} auth -V {{ user.username }}_view
-createUser {{ user.username }} MD5 {{ user.passphrase }} AES
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 view {{ user.username }}_view included {{ user.view }}
 {%- endfor %}
 

--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -17,7 +17,7 @@
     },
     'Debian': {
         'pkg': 'snmpd',
-        'pkgutils': 'snmp-utils',
+        'pkgutils': 'snmp',
         'service': 'snmpd',
         'servicetrap': 'snmptrapd',
         'config': '/etc/snmp/snmpd.conf',


### PR DESCRIPTION
Hi,

in map.jinja I fixed the pkgutils name for debian and I added options to change auth- and priv protocol for snmpv3 users wihtout changing the current default settings.

Kind regards.