### PR TITLE
Manage MIB files if source is not None (YAML ~)

### DIFF
--- a/snmp/confagent.sls
+++ b/snmp/confagent.sls
@@ -4,6 +4,7 @@ include:
   - snmp
 
 {% for name, source in salt['pillar.get']("snmp:conf:mibs").items() %}
+{% if source %}
 snmp_mib_{{ name }}:
   file.managed:
     - name: {{ snmp.mibsdir }}/{{ name }}.txt
@@ -14,6 +15,7 @@ snmp_mib_{{ name }}:
     - mode: 644
     - watch_in:
       - service: {{ snmp.service }}
+{% endif %}
 {% endfor %}
 
 snmp_agentconf:


### PR DESCRIPTION
We copy MIB file during installation from preinstalled vendor's directory, so we don't manage it by ourselves.