### PR TITLE
Extract snmp:conf pillar in separate file to apply layered configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,3 +39,57 @@ Configures the trap service.
 ------------
 
 Sets snmp runtime options.
+
+
+Layered configuration
+=====================
+
+Since SNMP can be integrated with many services, it may be handy to split configuration between several files,
+each belonging to different packages and teams.
+For example, you may setup generic SNMP configuration in common pillar file, and it will include:
+
+.. code:: yaml
+
+    snmp:
+      conf:
+        settings:
+          logconnects: false
+          sysServices: 72
+
+Whereas team, that wants to monitor GPFS with SNMP on the same cluster will add this pillar file to their package:
+
+.. code:: yaml
+
+    snmp:
+      conf:
+        settings:
+          master: ['agentx']
+          AgentXSocket: tcp:localhost:705
+        rocommunities:
+          - gpfs
+        mibs:
+          GPFS: salt://gpfs/files/GPFS-mib.txt
+
+To utilize this ability of layered configuration, you can modify snmp/conf.jinja file in following manner:
+
+.. code:: jinja
+
+    # Generic configuration:
+    {% set conf = salt['pillar.get']('snmp:conf', {}) %}
+
+    # Imagine you have team_names list which consist of packages provided
+    # by set of independent teams inside your company:
+    {% for team in team_names %}
+    {% set conf = salt['pillar.get'](
+        team + ":snmp",
+        default=conf,
+        merge=True)
+    %}
+    {% endfor %}
+
+    # Afterall there might configuration specific to current deployment in separate pillar file:
+    {% set conf = salt['pillar.get'](
+        "user:snmp",
+        default=conf,
+        merge=True)
+    %}

--- a/snmp/conf.jinja
+++ b/snmp/conf.jinja
@@ -1,0 +1,1 @@
+{% set conf = salt['pillar.get']('snmp:conf', {}) %}

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -1,4 +1,5 @@
 {% from "snmp/map.jinja" import snmp with context %}
+{% from "snmp/conf.jinja" import conf with context -%}
 
 include:
   - snmp
@@ -8,7 +9,7 @@ snmp_conf:
     - name: {{ snmp.config }}
     - template: jinja
     - context:
-      config: {{ salt['pillar.get']('snmp:conf:settings', {}) }}
+      config: {{ conf.get('settings', {}) }}
     - source: {{ snmp.source }}
     - user: root
     - group: root

--- a/snmp/confagent.sls
+++ b/snmp/confagent.sls
@@ -1,9 +1,10 @@
 {% from "snmp/map.jinja" import snmp with context %}
+{% from "snmp/conf.jinja" import conf with context -%}
 
 include:
   - snmp
 
-{% for name, source in salt['pillar.get']("snmp:conf:mibs").items() %}
+{% for name, source in conf.get("mibs", {}).items() %}
 {% if source %}
 snmp_mib_{{ name }}:
   file.managed:

--- a/snmp/files/snmp.conf
+++ b/snmp/files/snmp.conf
@@ -1,3 +1,5 @@
-{% for name in salt['pillar.get']("snmp:conf:mibs") %}
+{% from "snmp/conf.jinja" import conf with context -%}
+
+{% for name in conf.get("mibs", {}) %}
 mibs +{{name}}
 {% endfor %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -1,3 +1,5 @@
+{% from "snmp/conf.jinja" import conf with context -%}
+
 ###############################################################################
 #
 # {{ salt['pillar.get']('SALT_MANAGED') }}
@@ -46,7 +48,7 @@
 # First, map the community name "public" into a "security name"
 
 #       sec.name  source          community
-{%- for entry in salt['pillar.get']('snmp:conf:com2sec', '') %}
+{%- for entry in conf.get('com2sec', []) %}
 com2sec {{ entry.name }} {{ entry.source }} {{ entry.community }}
 {%- endfor %}
 
@@ -54,7 +56,7 @@ com2sec {{ entry.name }} {{ entry.source }} {{ entry.community }}
 # Second, map the security name into a group name:
 
 #       groupName      securityModel securityName
-{%- for entry in salt['pillar.get']('snmp:conf:groups', '') %}
+{%- for entry in conf.get('groups', []) %}
 group {{ entry.name }} {{ entry.version }} {{ entry.secname }}
 {%- endfor %}
 
@@ -63,7 +65,7 @@ group {{ entry.name }} {{ entry.version }} {{ entry.secname }}
 
 # Make at least  snmpwalk -v 1 localhost -c public system fast again.
 #       name           incl/excl     subtree         mask(optional)
-{%- for entry in salt['pillar.get']('snmp:conf:views', '') %}
+{%- for entry in conf.get('views', []) %}
 view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if entry.mask }}
 {%- endfor %}
 
@@ -72,7 +74,7 @@ view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if entry.ma
 # Finally, grant the group read-only access to the systemview view.
 
 #       group          context sec.model sec.level prefix read   write  notif
-{%- for entry in salt['pillar.get']('snmp:conf:access', '') %}
+{%- for entry in conf.get('access', []) %}
 access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read }} {{ entry.write }} {{ entry.notify }}
 {%- endfor %}
 
@@ -166,29 +168,36 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 #access  notConfigGroup ""      any       noauth    exact  roview rwview none
 
 # Version 1/2c users (read only)
-{%- for rocommunity in salt['pillar.get']('snmp:conf:rocommunities', '') %}
-{%- set source = salt['pillar.get']('snmp:conf:rocommunities:'+ rocommunity +':source', '') %}
+{%- for community in conf.get('rocommunities', []) %}
+{%- if community.__class__ == {}.__class__ %}
+{%- set source = community.get('source', '') %}
+{%- else %}
+{%- set source = '' %}
+{%- endif %}
 {%- if source.__class__ in (().__class__, [].__class__) %}
 {%- for src in source %}
-rocommunity     {{ rocommunity }}       {{ src}}
+rocommunity     {{ community }}       {{ src }}
 {%- endfor %}
 {%- else %}
-rocommunity     {{ rocommunity }}       {{ source }}
+rocommunity     {{ community }}       {{ source }}
 {%- endif %}
 {%- endfor %}
 
 # Version 1/2c users (read/write)
-{%- for rwcommunity in salt['pillar.get']('snmp:conf:rwcommunities', '') %}
-{%- set source = salt['pillar.get']('snmp:conf:rwcommunities:'+ rwcommunity +':source', '') %}
+{%- for community in conf.get('rwcommunities', []) %}
+{%- if community.__class__ == {}.__class__ %}
+{%- set source = community.get('source', '') %}
+{%- else %}
+{%- set source = '' %}
+{%- endif %}
 {%- if source.__class__ in (().__class__, [].__class__) %}
 {%- for src in source %}
-rwcommunity     {{ rwcommunity }}       {{ src}}
+rwcommunity     {{ community }}       {{ src }}
 {%- endfor %}
 {%- else %}
-rwcommunity     {{ rwcommunity }}       {{ source }}
+rwcommunity     {{ community }}       {{ source }}
 {%- endif %}
 {%- endfor %}
-
 
 
 ###############################################################################
@@ -198,8 +207,8 @@ rwcommunity     {{ rwcommunity }}       {{ source }}
 # It is also possible to set the sysContact and sysLocation system
 # variables through the snmpd.conf file:
 
-syslocation "{{ salt['pillar.get']('snmp:conf:location', 'Unknown (add saltstack pillar)') }}"
-syscontact "{{ salt['pillar.get']('snmp:conf:syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+syslocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
+syscontact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
 
 # Example output of snmpwalk:
 #   % snmpwalk -v 1 localhost -c public system
@@ -220,9 +229,9 @@ syscontact "{{ salt['pillar.get']('snmp:conf:syscontact', 'Root <root@localhost>
 # If the following option is commented out, snmpd will print each incoming
 # connection, which can be useful for debugging.
 
-{% if salt['pillar.get']('snmp:conf:logconnects', 'false') == 'false' %}
+{% if conf.get('logconnects', 'false') == 'false' %}
 dontLogTCPWrappersConnects yes
-{% elif salt['pillar.get']('snmp:conf:logconnects', 'false') == 'true' %}
+{% elif conf.get('logconnects', 'false') == 'true' %}
 # dontLogTCPWrappersConnects yes
 {% endif %}
 
@@ -506,12 +515,12 @@ dontLogTCPWrappersConnects yes
 
 # Version 3 users
 
-{%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
+{%- for user in conf.get('rousers', '') %}
 rouser {{ user.username }} auth -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 {%- endfor %}
 
-{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
+{%- for user in conf.get('rwusers', '') %}
 rwuser {{ user.username }} auth -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 {%- endfor %}

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -1,3 +1,5 @@
+{% from "snmp/conf.jinja" import conf with context -%}
+
 # {{ salt['pillar.get']('SALT_MANAGED') }}
 #
 # DO NOT EDIT
@@ -13,11 +15,11 @@
 ##############################################################################
 # System contact information
 #
-sysLocation "{{ salt['pillar.get']('snmp:conf:location', 'Unknown (add saltstack pillar)') }}"
-sysContact "{{ salt['pillar.get']('snmp:conf:syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+sysLocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
+sysContact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
 
-{% if salt['pillar.get']('snmp:conf:logconnects') is not none %}
-{%- if salt['pillar.get']('snmp:conf:logconnects') %}
+{% if conf.get('logconnects') is not none %}
+{%- if conf.get('logconnects') %}
 # dontLogTCPWrappersConnects yes
 {%- else %}
 dontLogTCPWrappersConnects yes
@@ -32,7 +34,7 @@ dontLogTCPWrappersConnects yes
 # First, map the community name "public" into a "security name"
 
 #       sec.name  source          community
-{%- for entry in salt['pillar.get']('snmp:conf:com2sec', '') %}
+{%- for entry in conf.get('com2sec', '') %}
 com2sec {{ entry.name }} {{ entry.source }} {{ entry.community }}
 {%- endfor %}
 
@@ -40,7 +42,7 @@ com2sec {{ entry.name }} {{ entry.source }} {{ entry.community }}
 # Second, map the security name into a group name:
 
 #       groupName      securityModel securityName
-{%- for entry in salt['pillar.get']('snmp:conf:groups', '') %}
+{%- for entry in conf.get('groups', '') %}
 group {{ entry.name }} {{ entry.version }} {{ entry.secname }}
 {% endfor %}
 
@@ -49,7 +51,7 @@ group {{ entry.name }} {{ entry.version }} {{ entry.secname }}
 
 # Make at least  snmpwalk -v 1 localhost -c public system fast again.
 #       name           incl/excl     subtree         mask(optional)
-{%- for entry in salt['pillar.get']('snmp:conf:views', '') %}
+{%- for entry in conf.get('views', []) %}
 view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if entry.mask }}
 {%- endfor %}
 
@@ -57,13 +59,13 @@ view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if entry.ma
 # Finally, grant the group read-only access to the systemview view.
 
 #       group          context sec.model sec.level prefix read   write  notif
-{%- for entry in salt['pillar.get']('snmp:conf:access', '') %}
+{%- for entry in conf.get('access', []) %}
 access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read }} {{ entry.write }} {{ entry.notify }}
 {%- endfor %}
 
 # Version 1/2c users (read only)
-{%- for rocommunity in salt['pillar.get']('snmp:conf:rocommunities', '') %}
-{%- set source = salt['pillar.get']('snmp:conf:rocommunities:'+ rocommunity +':source', '') %}
+{%- for rocommunity in conf.get('rocommunities', []) %}
+{%- set source = rocommunity.get('source', []) %}
 {%- if source.__class__ in (().__class__, [].__class__) %}
 {%- for src in source %}
 rocommunity {{ rocommunity }} {{ src}}
@@ -74,8 +76,8 @@ rocommunity {{ rocommunity }} {{ source }}
 {%- endfor %}
 
 # Version 1/2c users (read/write)
-{%- for rwcommunity in salt['pillar.get']('snmp:conf:rwcommunities', '') %}
-{%- set source = salt['pillar.get']('snmp:conf:rwcommunities:'+ rwcommunity +':source', '') %}
+{%- for rwcommunity in conf.get('rwcommunities', []) %}
+{%- set source = rwcommunity.get('source', []) %}
 {%- if source.__class__ in (().__class__, [].__class__) %}
 {%- for src in source %}
 rwcommunity {{ rwcommunity }} {{ src}}
@@ -86,13 +88,13 @@ rwcommunity {{ rwcommunity }} {{ source }}
 {%- endfor %}
 
 # Version 3 users (read only)
-{%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
+{%- for user in conf.get('rousers', []) %}
 rouser {{ user.username }} auth -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 {%- endfor %}
 
 # Version 3 users (read/write)
-{%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
+{%- for user in conf.get('rwusers', []) %}
 rwuser {{ user.username }} auth -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
 {%- endfor %}


### PR DESCRIPTION
While this change may look naive, we use this level of abstraction very effectively for splitting snmp configuration files between several independent projects.
I don't want product-specific code be merged in official repo, but this abstraction-layer can be useful to someone else and will keep my fork with small and easy patch.
If you are interested in how do I utilize this configuration separation, please check out my branch 'specific': https://github.com/peterdemin/snmp-formula/blob/specific/snmp/conf.jinja
