### PR TITLE
Improve SNMP v3 user support

### DIFF
--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -507,13 +507,13 @@ dontLogTCPWrappersConnects yes
 # Version 3 users
 
 {%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
-rouser {{ user.username }} auth -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
+rouser {{ user.username }} {{ user.seclevel }} {{% if user.view != '' %} -V {{ user.view }}{% endif %}}
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.authpassphrase }} {{ user.get('privproto', 'AES') }} {{ user.privpassphrase }}
 {%- endfor %}
 
 {%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
-rwuser {{ user.username }} auth -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
+rwuser {{ user.username }} {{ user.seclevel }} {{% if user.view != '' %} -V {{ user.view }}{% endif %}}
+createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.authpassphrase }} {{ user.get('privproto', 'AES') }} {{ user.privpassphrase }}
 {%- endfor %}
 
 {% for declaration, values in config.items() %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -507,12 +507,12 @@ dontLogTCPWrappersConnects yes
 # Version 3 users
 
 {%- for user in salt['pillar.get']('snmp:conf:rousers', '') %}
-rouser {{ user.username }} {{ user.seclevel }} {{% if user.view != '' %} -V {{ user.view }}{% endif %}}
+rouser {{ user.username }} {{ user.seclevel }} -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.authpassphrase }} {{ user.get('privproto', 'AES') }} {{ user.privpassphrase }}
 {%- endfor %}
 
 {%- for user in salt['pillar.get']('snmp:conf:rwusers', '') %}
-rwuser {{ user.username }} {{ user.seclevel }} {{% if user.view != '' %} -V {{ user.view }}{% endif %}}
+rwuser {{ user.username }} {{ user.seclevel }} -V {{ user.view }}
 createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.authpassphrase }} {{ user.get('privproto', 'AES') }} {{ user.privpassphrase }}
 {%- endfor %}
 


### PR DESCRIPTION
Improve SNMP v3 user support by implementing security levels (noauth|auth|priv), making specific view context optional, and adding support for privacy passphrase.
