### PR TITLE
Windows support

### DIFF
--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -50,6 +50,9 @@ FreeBSD:
     pkg: net-snmp
     pkgutils: net-snmp
     rootgroup: wheel
+Windows:
+    pkg: SNMP-Service
+    pkgutils: SNMP-WMI-Provider
 {% endload %}
 
 {% load_yaml as rhel_specific %}
@@ -74,3 +77,32 @@ FreeBSD:
 {% if user_override %}
     {% do snmp.update(user_override) %}
 {% endif %}
+
+{% set Sources = [] %}
+{% for rocommunity in salt['pillar.get']('snmp:conf:rocommunities', '') %}
+  Community: {{ rocommunity }}
+  {% set source = salt['pillar.get']('snmp:conf:rocommunities:'+ rocommunity +':source', '') %}
+  {% if source.__class__ in (().__class__, [].__class__) %}
+    {% for i in source %}
+    {% set WinManager = Sources.append(i) %}
+    {% endfor %}
+  {% elif source != '' %}
+    {% set WinManager = Sources.append(source) %}
+  {% else %}
+  {% endif %}
+{% endfor %}
+
+{% for rwcommunity in salt['pillar.get']('snmp:conf:rwcommunities', '') %}
+  Community: {{ rwcommunity }}
+  {% set source = salt['pillar.get']('snmp:conf:rwcommunities:'+ rwcommunity +':source', '') %}
+  {% if source.__class__ in (().__class__, [].__class__) %}
+    {% for i in source %}
+    {% set WinManager = Sources.append(i) %}
+    {% endfor %}
+  {% elif source != '' %}
+    {% set WinManager = Sources.append(source) %}
+  {% else %}
+  {% endif %}
+{% endfor %}
+
+{% do snmp.update({'Sources': Sources}) %}

--- a/snmp/windows.sls
+++ b/snmp/windows.sls
@@ -18,40 +18,31 @@ Core Package:
   cmd.run:
     - name: 'dism.exe /online /enable-feature /featurename:"SNMP" /featurename:"WMISnmpProvider"'
 {% else %}
-### Windows 2008r2 Fallback
 Core Package:
   cmd.run:
     - name: 'servermanagercmd -install {{ snmp.pkg }} -allSubFeatures'
 {% endif %}
 
-#### Location Key
 sysLocation:
   cmd.run:
     - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\RFC1156Agent" /v sysLocation /t REG_SZ /d "{{ salt['pillar.get']('snmp:conf:location', 'Unknown (add saltstack pillar)') }}" /f'
 
-#### System Contact Key
 sysContact:
   cmd.run:
     - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\RFC1156Agent" /v sysContact /t REG_SZ /d "{{ salt['pillar.get']('snmp:conf:syscontact', 'Root <root@localhost> (add saltstack pillar)') }}" /f'
 
-{% for manager in snmp.WindowsManager %}
+{% for manager in snmp.Sources %}
 HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\PermittedManagers{{ loop.index }}:
   cmd.run:
     - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\PermittedManagers" /v {{ loop.index }} /t REG_SZ /d observium.erickson.is /f'
 {% endfor %}
 
-# Version 1/2c users (read/write)
-#1/1  - None
-#2/2  - Notify
-#4/4  - Read Only
-#8/10 - Read Write
 {%- for rwcommunity in salt['pillar.get']('snmp:conf:rwcommunities', '') %}
 HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities:
   cmd.run:
     - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities" /v {{ rwcommunity }} /t REG_DWORD /d 10 /f'
 {%- endfor -%}
 
-#4/4 - Read Only
 {%- for rocommunity in salt['pillar.get']('snmp:conf:rocommunities', '') %}
 HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities:
   cmd.run:

--- a/snmp/windows.sls
+++ b/snmp/windows.sls
@@ -1,0 +1,67 @@
+{% from "snmp/map.jinja" import snmp with context %}
+{% set mushStamp = salt['grains.get']('osfinger', 'NA') %}
+
+{% if mushStamp in ('Windows-2016Server', 'Windows-2012Server') %}
+Core Package:
+  win_servermanager.installed:
+    - force: True
+    - recurse: True
+    - name: {{ snmp.pkg }}
+    
+WMI Poller Package:
+  win_servermanager.installed:
+    - force: True
+    - recurse: True
+    - name: {{ snmp.pkgutils }}
+{% elif mushStamp in ('Windows-10') %}
+Core Package:
+  cmd.run:
+    - name: 'dism.exe /online /enable-feature /featurename:"SNMP" /featurename:"WMISnmpProvider"'
+{% else %}
+### Windows 2008r2 Fallback
+Core Package:
+  cmd.run:
+    - name: 'servermanagercmd -install {{ snmp.pkg }} -allSubFeatures'
+{% endif %}
+
+#### Location Key
+sysLocation:
+  cmd.run:
+    - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\RFC1156Agent" /v sysLocation /t REG_SZ /d "{{ salt['pillar.get']('snmp:conf:location', 'Unknown (add saltstack pillar)') }}" /f'
+
+#### System Contact Key
+sysContact:
+  cmd.run:
+    - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\RFC1156Agent" /v sysContact /t REG_SZ /d "{{ salt['pillar.get']('snmp:conf:syscontact', 'Root <root@localhost> (add saltstack pillar)') }}" /f'
+
+{% for manager in snmp.WindowsManager %}
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\PermittedManagers{{ loop.index }}:
+  cmd.run:
+    - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\PermittedManagers" /v {{ loop.index }} /t REG_SZ /d observium.erickson.is /f'
+{% endfor %}
+
+# Version 1/2c users (read/write)
+#1/1  - None
+#2/2  - Notify
+#4/4  - Read Only
+#8/10 - Read Write
+{%- for rwcommunity in salt['pillar.get']('snmp:conf:rwcommunities', '') %}
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities:
+  cmd.run:
+    - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities" /v {{ rwcommunity }} /t REG_DWORD /d 10 /f'
+{%- endfor -%}
+
+#4/4 - Read Only
+{%- for rocommunity in salt['pillar.get']('snmp:conf:rocommunities', '') %}
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities:
+  cmd.run:
+    - name: 'reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SNMP\Parameters\ValidCommunities" /v {{ rocommunity }} /t REG_DWORD /d 4 /f'
+{% endfor -%}
+
+snmp:
+  service.running:
+    - reload: True
+    - watch:
+        - cmd: HKEY_LOCAL_MACHINE/SYSTEM/CurrentControlSet/services/SNMP/Parameters/ValidCommunities
+        - cmd: syslocation
+        - cmd: sysContact


### PR DESCRIPTION
I needed to configure Windows SNMP in a small network.  I added baseline Windows Support.  This supports v2c only, I have not tested the RW configuration. 

# Notes
 - Uses identical pillar configuration
 - Works only with 'snmp.windows' state.

Windows has officially deprecated SNMP, but it still works.  May be useful for others.