### PR TITLE
Bugfix: logconnects parameter is ignored due to string comparison

### DIFF
--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -205,10 +205,12 @@ syscontact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pill
 # If the following option is commented out, snmpd will print each incoming
 # connection, which can be useful for debugging.
 
-{% if conf.get('logconnects', 'false') == 'false' %}
-dontLogTCPWrappersConnects yes
-{% elif conf.get('logconnects', 'false') == 'true' %}
+{% if conf.get('logconnects') is not none %}
+{%- if conf.get('logconnects') %}
 # dontLogTCPWrappersConnects yes
+{%- else %}
+dontLogTCPWrappersConnects yes
+{%- endif %}
 {% endif %}
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The 'logconnects' parameter in the pillar.example is a boolean. It is also handled as a boolean in snmp/files/snmpd.conf.minimal.

However in snmp/files/snmpd.conf the parameter is handled as a string and otherwise ignored.

This change makes the comparison in snmpd.conf identical to the one in snmpd.conf.minimal.