### PR TITLE
Support Debian Stretch

### DIFF
--- a/snmp/codenamemap.yaml
+++ b/snmp/codenamemap.yaml
@@ -1,0 +1,9 @@
+stretch:
+  # use the default OS parameters except for -LS6d (which was -Lsd)
+  snmpdargs: -LS6d -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f
+  # the value null means that the default OS parameters should be used
+  trapdargs: null
+  options: /etc/systemd/system/snmpd.service
+  optionstrap: /etc/systemd/system/snmptrapd.service
+  sourceoptions: salt://snmp/files/snmpd-systemd.options
+  sourceoptionstrap: salt://snmp/files/snmptrapd-systemd.options

--- a/snmp/conf.jinja
+++ b/snmp/conf.jinja
@@ -1,1 +1,2 @@
-{% set conf = salt['pillar.get']('snmp:conf', {}) %}
+{% from "snmp/map.jinja" import snmp with context %}
+{% set conf = snmp.get('conf', {}) -%}

--- a/snmp/conftrap.sls
+++ b/snmp/conftrap.sls
@@ -1,7 +1,7 @@
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:
-  - snmp
+  - snmp.trap
 
 snmptrap_conf:
   file.managed:

--- a/snmp/files/snmpd-systemd.options
+++ b/snmp/files/snmpd-systemd.options
@@ -1,0 +1,18 @@
+# DO NOT EDIT
+#
+# This file is managed by Salt via {{ source }}
+# Modify the config that generates this file instead
+#
+{%- from "snmp/map.jinja" import snmp with context %}
+
+.include /lib/systemd/system/snmpd.service
+
+[Service]
+{%- if snmp.mibs is not none %}
+Environment="MIBS='{{ snmp.mibs }}'"
+{%- endif %}
+
+{%- if snmp.snmpdargs is not none %}
+ExecStart=
+ExecStart=/usr/sbin/snmpd {{ snmp.snmpdargs }}
+{%- endif %}

--- a/snmp/files/snmptrapd-systemd.options
+++ b/snmp/files/snmptrapd-systemd.options
@@ -1,0 +1,14 @@
+# DO NOT EDIT
+#
+# This file is managed by Salt via {{ source }}
+# Modify the config that generates this file instead
+#
+{%- from "snmp/map.jinja" import snmp with context %}
+
+.include /lib/systemd/system/snmptrapd.service
+
+[Service]
+{%- if snmp.trapdargs is not none %}
+ExecStart=
+ExecStart=/usr/sbin/snmptrapd {{ snmp.trapdargs }}
+{%- endif %}

--- a/snmp/init.sls
+++ b/snmp/init.sls
@@ -9,7 +9,7 @@ snmp:
     - require:
       - pkg: {{ snmp.pkg }}
 
-{% if grains['os_family'] == 'Debian' %}
+{% if grains['os_family'] == 'Debian' and grains['osmajorrelease'] < 9 %}
 include:
   - snmp.default
 {% endif %}

--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -1,4 +1,4 @@
-{# Debian uses snmpd init script for both snmpd/snmptrapd! #}
+{# Debian (up to and excluding 9.x 'Stretch') uses snmpd init script for both snmpd/snmptrapd! #}
 
 {% load_yaml as snmp %}
 service: snmpd
@@ -69,6 +69,12 @@ FreeBSD:
 
 {% if rhel_addition %}
     {% do snmp.update(rhel_addition) %}
+{% endif %}
+
+{% import_yaml "snmp/codenamemap.yaml" as codemap %}
+{% set oscode = salt['grains.filter_by'](codemap, grain='oscodename', default=None) %}
+{% if oscode is not none %}
+{%   do snmp.update(oscode) %}
 {% endif %}
 
 {% if user_override %}

--- a/snmp/optionstrap.sls
+++ b/snmp/optionstrap.sls
@@ -1,7 +1,7 @@
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:
-  - snmp
+  - snmp.trap
 
 trap_options:
   file.managed:


### PR DESCRIPTION
This branch provides support for Debian Stretch. 

Although "it works for me", the initial goal of this pull request is not to get it merged upstream but to solicit feedback on how to improve it. For example, one of the things I noticed was that current Debian support in the snmp formula is somewhat different due to the fact Debian used a single file to specify the options to snmp and snmptrap. That is not the case any more with Stretch so maybe it is time to get rid of that special handling.

Apart from things that can be improved, maybe some changes I made are just plain wrong. So feel free to comment.

