### PR TITLE
Remove quotes from `syslocation` and `syscontact`

### DIFF
--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -183,8 +183,8 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 # It is also possible to set the sysContact and sysLocation system
 # variables through the snmpd.conf file:
 
-syslocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
-syscontact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+syslocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
+syscontact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
 
 # Example output of snmpwalk:
 #   % snmpwalk -v 1 localhost -c public system

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -16,8 +16,8 @@
 ##############################################################################
 # System contact information
 #
-sysLocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
-sysContact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+sysLocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
+sysContact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
 
 {% if conf.get('logconnects') is not none %}
 {%- if conf.get('logconnects') %}


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

`syslocation` and `syscontact` values are reported verbatim. When quoted, this includes the quotes.  

For example, `syslocation "Timbuktu"` reports as `"Timbuktu"` when `Timbuktu` is the expected/desired value.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

None

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

None

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


