### PR TITLE
Secure SNMPv3 user creation

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -113,7 +113,7 @@ For example, you may setup generic SNMP configuration in common pillar file, and
     snmp:
       conf:
         settings:
-          logconnects: false
+          dontLogTCPWrappersConnects: false
           sysServices: 72
 
 Whereas team, that wants to monitor GPFS with SNMP on the same cluster will add this pillar file to their package:

--- a/pillar.example
+++ b/pillar.example
@@ -1,114 +1,191 @@
-# -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
 snmp:
-  # lookup:
-  #   snmpdargs: '-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a'
-  #   trapdargs: '-Lsd -p /var/run/snmptrapd.pid'
-  #   trapdrun: 'no' # Needs "'", otherwise it'll be a bool
+  # Use `lookup` to override default config values
+  #   (such as those found in snmp/map.jinja)
+  lookup:
+    snmpdargs: '-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a'
+    trapdargs: '-Lsd -p /var/run/snmptrapd.pid'
+    trapdrun: 'no' # Single quote wrap to avoid boolean behavior
 
   conf:
-    location: 'Unknown (add saltstack pillar)'
-    syscontact: 'Root <root@localhost> (add saltstack pillar)'
-    logconnects: false
-    # disk checks
-    # disk: /
-    # disks:
-    #  - /
-    # vacm com2sec's (map communities into security names)
-    # com2sec:
-    #  - name: local
-    #    source: localhost
-    #    community: localhost
-    # vacm group's (map security names to group names)
-    # groups:
-    #  - name: ROgroup1
-    #    version: usm
-    #    secname: local
-    #  - name: ROgroup1
-    #    version: v1
-    #    secname: local
-    #  - name: ROgroup1
-    #    version: v2c
-    #    secname: local
-    #  - name: Other
-    #    version: usm
-    #    secname: local
-    #  - name: Other
-    #    version: v1
-    #    secname: local
-    #  - name: Other
-    #    version: v2c
-    #    secname: local
-    # vacm views (map mib trees to views)
+    ## Config reference: http://www.net-snmp.org/docs/man/snmpd.conf.html
+    sysLocation: 'IT Office, Third Floor'
+    sysContact: 'John Doe <jdoe@fakellc.net>'
+    # (SALT: Omitting dontLogTCPWrappersConnects defaults to 'true')
+    dontLogTCPWrappersConnects: true
+
+    #################################
+    ###   Disk Usage Monitoring   ###
+    #################################
+    # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAS
+    #disks:
+    #  (path): (min-space-in-kB)
+    disks:
+      '/': 1000000
+      '/nfs/apache': 250000
+
+    ##############################
+    ###   VACM Configuration   ###
+    ##############################
+    # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAL
+    # `com2sec` : map an SNMPv1 or SNMPv2c community string to a 
+    #             security name - either from a particular range of 
+    #             source addresses, or globally ("default")
+    #             (SALT: multiple entries allowed, list syntax)
+    #com2sec:
+    #  - name: (helpful label)
+    #    source: {hostname|IP+Mask|IP+Subnet}
+    #    community: (community string)
+    com2Sec:
+      - name: localSec
+        source: 10.20.30.0/24
+        community: ROwrowrowtheboat
+      - name: secOps
+        source: 110.120.130.0/24
+        community: seriousSecurityThx
+    #
+    # `group` : maps a security name (in the specified security model)
+    #           into a named group
+    #           (SALT: multiple entries allowed, list syntax)
+    #groups:
+    #  - name: (helpful label)
+    #    version: {v1|v2c|usm|tsm|ksm}
+    #    secname: (any valid `com2Sec` entry defined)
+    groups:
+      - name: ROwers1
+        version: v1
+        secname: localSec
+      - name: ROwers2
+        version: v2c
+        secname: localSec
+      - name: SecEngTeam
+        version: usm
+    #
+    # `view` : defines a named "view" - a subset of the overall OID tree
+    #          (SALT: multiple entries allowed, list syntax)
+    #views:
+    #  - name: (helpful label)
+    #    type: {included|excluded}
+    #    oid: (oid string)
+    #    mask: (list of hex octets to match against)  ## OPTIONAL
     views:
       - name: all
         type: included
         oid: '.1'
-        # optional mask
         mask: 80
-    # vacm access (map groups to views with access restrictions)
-    # access:
-    #  - name: ROgroup1
-    #    context: '""'
-    #    match: any
-    #    level: noauth
-    #    prefix: exact
-    #    read: all
-    #    write: none
-    #    notify: none
-    #  - name: Other
-    #    context: "cont"
-    #    match: any
-    #    level: noauth
-    #    prefix: exact
-    #    read: all
-    #    write: none
-    #    notify: none
-    # v1/2c read-only communities
+      - name: ifRow4
+        type: included
+        oid: '.1.3.6.1.2.1.2.2.1.0.4'
+      - name: iso3
+        type: included
+        oid: '.iso.org.dod.mgmt'
+    #         
+    # `access` : maps from a group of users/communities (with a particular 
+    #            security model and minimum security level, and in a 
+    #            specific context) to one of three views, depending on the
+    #            request being processed
+    #            (SALT: multiple entries allowed, list syntax)
+    #access:
+    #  - name: (any valid `group` entry defined)
+    #    context: (incoming request context) # can be leftout to assume 'blank'
+    #    match: {any|v1|v2c|usm|tsm|ksm}
+    #    level: {noauth|auth|priv} # v1 & v2c require 'noauth'
+    #    prefix: {exact|prefix}
+    #    read: {all|none} # omitting selects 'none'
+    #    write: {all|none} # omitting selects 'none'
+    #    notify: {all|none} # omitting selects 'none'
+    access:
+      - name: ROwers1
+        match: any
+        level: noauth
+        prefix: exact
+        read: all
+      - name: SecEngTeam
+        match: any
+        level: auth
+        prefix: exact
+        read: all
+        write: all
+    
+    ######################################
+    ###   Traditional Access Control   ###
+    ######################################
+    # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAK
+    ## v1/v2c ##
+    # rXcommunity - specify an SNMPv1 or SNMPv2c community that will be 
+    #               allowed read-only (if `rocommunity`) or be allowed
+    #               read-write (if `rwcommunity`) access
+    #               (SALT: suffix '6' for ipv6 version of the communities,
+    #                      such as 'rocommunities6' or 'rwcommunities6')
+    # SYNTAX WITH SOURCE
+    #rXcommunities:
+    #  (community string):
+    #    source: {hostname|IP+Mask|IP+Subnet} or [{hostname|IP+Mask|IP+Subnet}, ...] # list format or single entry
     rocommunities:
       public:
-        source: [localhost, 192.168.0.0/24, 192.168.1.0/24]
-      withoutsource: null
-    # or
-    # rocommunities:
-    #   - public
-    # rocommunities6:
-    #  public:
-    #    source: 2001:DB8::1
-    # v1/2c read-write communities
+        source: [localhost, 192.168.0.0/24, 2001:DB8::1]
     rwcommunities:
       private:
         source: 192.168.1.0/24
-    # v3 users for read-only
+    # SYNTAX WITHOUT SOURCE
+    #rXcommunities:
+    #  - (community string)
+    #  - (another community string)
+    rocommunities:
+      - monitoring
+      - dontbreakit
+    rwcommunities:
+      - privatestuff
+    ## v3 ##
+    # (SALT: The default authproto will be SHA, instead of MD5,
+    #        and the default privproto will be AES, instead of
+    #        DES, for the sake of security.
+    #        `securitylevel` = 'priv' enforces encryption, in
+    #        addition to auth, which *requires* privpassphrase 
+    #        to be defined.
+    #rXusers:
+    #  - username: (snmpv3 user name)
+    #    authpassphrase: (authentication password)
+    #    privpassphrase: (encryption password) ## optional only if `securitylevel` = 'auth'
+    #    securitylevel: {auth|priv} # omitting selects 'auth'                    
+    #    authproto: {MD5|SHA} # omitting selects 'SHA'
+    #    privproto: {DES|AES} # omitting selects 'AES'
+    #    view: (any valid `view` entry defined) ## OPTIONAL
     rousers:
-      - username: 'myv3user'
-        authpassphrase: 'myv3password'
-        view: all
-        # securitylevel: priv
-        # authproto: 'SHA'
-        # privproto: 'AES'
-        # privpassphrase: 'v3privpass'
-    # v3 users for read-write
+      - username: 'someNewUser'
+        authpassphrase: 'tklhgKipJF1nNY'
+        view: all        
     rwusers:
-      - username: 'myv3user_rw'
-        authpassphrase: 'myv3password'
-        view: all
-        # securitylevel: priv
-        # authproto: 'SHA'
-        # privproto: 'AES'
-        # privpassphrase: 'v3privpass'
-    # misc snmpd.conf settings
+      - username: 'somethingCICD'
+        authpassphrase: 'VPluOBhwmnFB6z'
+        privpassphrase: 'IO0wa0wROUSaeB'
+        securitylevel: priv
+        view: iso3
+
+    ########################################
+    ###   Miscellaneous SNMPD Settings   ###
+    ########################################
+    # (SALT: These are example settings, but any valid setting
+    #        should be acceptable here.)
     settings:
-      # agentAddress: 'udp:161,udp6:[::1]:161'
+      # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAD
+      #agentAddress: [<transport-specifier>:]<transport-address>
+      agentAddress: 'udp:161,udp6:[::1]:161'
       sysServices: 72
       master: ['agentx']
-    # custom MIB files
+    # (SALT: For custom MIB files, follow this syntax)
     # mibs:
     #     <MIB name>: salt://<path to MIB.txt>
+    mibs:
+      GPFS: salt://gpfs/files/GPFS-mib.txt
+    # (SALT: The name field for `extent` entries can be a human
+    #        readable string or an OID string.)
+    # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbAZ
     extend:
       - name: 'HTTPD_PIDS'
         prog: '/bin/sh /path/to/check_apache.sh'
+    # ref: http://www.net-snmp.org/docs/man/snmpd.conf.html#lbBD
     dlmod:
       - name: 'nstAgentPluginObject'
         sharedobject: '/path/to/nstAgentPluginObject.so'

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -37,13 +37,13 @@ snmpv3 creating {{ user.username }} step 2 of 3:
     - location: end
     - content: {{ v3_createUser_string(user) }}
     - show_changes: False
-    - require:
+    - onchanges:
       - snmpv3 creating {{ user.username }} step 1 of 3
 
 snmpv3 creating {{ user.username }} step 3 of 3:
   service.running:
     - name: {{ snmp.service }}
-    - require:
+    - onchanges:
       - snmpv3 creating {{ user.username }} step 2 of 3
 {% endfor %}
 {% endfor %}

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -17,5 +17,3 @@ snmp_conf:
     - user: root
     - group: {{ snmp.rootgroup }}
     - mode: 644
-    - watch_in:
-      - service: {{ snmp.service }}

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -1,7 +1,8 @@
 # vim: ft=sls
 
 {% from "snmp/map.jinja" import snmp with context %}
-{% from "snmp/conf.jinja" import conf with context -%}
+{% from "snmp/conf.jinja" import conf with context %}
+{% from "snmp/macros.jinja" import v3_createUser_string with context -%}
 
 include:
   - snmp
@@ -17,3 +18,33 @@ snmp_conf:
     - user: root
     - group: {{ snmp.rootgroup }}
     - mode: 644
+
+{% if 'persistentconfig' in snmp %}
+{% for groups in ['rousers', 'rwusers'] %}
+{% for user in conf.get(groups, []) %}
+{% set securitylevel = 'authPriv' if user.get('securitylevel') == 'priv' else 'authNoPriv' %}
+{# if test fails, stop snmpd, add user to persistent config file, restart snmpd #}
+snmpv3 creating {{ user.username }} step 1 of 3:
+  service.dead:
+    - name: {{ snmp.service }}
+    - unless:
+      - "snmpget -v3 -l {{ securitylevel }} -u {{ user.username }} -a {{ user.get('authproto', 'SHA') }} -A {{ user.authpassphrase }} -x {{ user.get('privproto', 'AES') }} {% if securitylevel == "authPriv" %}-X {{ user.privpassphrase }}{% endif %} 127.0.0.1 1.3.6.1.2.1.1.5.0 -On"
+
+snmpv3 creating {{ user.username }} step 2 of 3:
+  file.line:
+    - name: {{ snmp.persistentconfig }}
+    - mode: insert
+    - location: end
+    - content: {{ v3_createUser_string(user) }}
+    - show_changes: False
+    - require:
+      - snmpv3 creating {{ user.username }} step 1 of 3
+
+snmpv3 creating {{ user.username }} step 3 of 3:
+  service.running:
+    - name: {{ snmp.service }}
+    - require:
+      - snmpv3 creating {{ user.username }} step 2 of 3
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 {% from "snmp/conf.jinja" import conf with context -%}
 

--- a/snmp/conftrap.sls
+++ b/snmp/conftrap.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:

--- a/snmp/default.sls
+++ b/snmp/default.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -1,5 +1,6 @@
 {% from "snmp/conf.jinja" import conf with context -%}
-{% from "snmp/macros.jinja" import v12c_communities with context -%}
+{% from "snmp/map.jinja" import snmp with context -%}
+{% from "snmp/macros.jinja" import v12c_communities,v3_createUser_string with context -%}
 
 ###############################################################################
 #
@@ -76,7 +77,7 @@ view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if 'mask' i
 
 #       group          context sec.model sec.level prefix read   write  notif
 {%- for entry in conf.get('access', []) %}
-access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read }} {{ entry.write }} {{ entry.notify }}
+access {{ entry.name }} {{ entry.context or '""' }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read or 'none' }} {{ entry.write or 'none' }} {{ entry.notify or 'none' }}
 {%- endfor %}
 
 # -----------------------------------------------------------------------------
@@ -121,7 +122,7 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 # snmpd daemon from any source! To avoid this use different names for your
 # community or split out the write access to a different community and
 # restrict it to your local network.
-# Also remember to comment the syslocation and syscontact parameters later as
+# Also remember to comment the sysLocation and sysContact parameters later as
 # otherwise they are still read only (see FAQ for net-snmp).
 #
 
@@ -183,8 +184,8 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 # It is also possible to set the sysContact and sysLocation system
 # variables through the snmpd.conf file:
 
-syslocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
-syscontact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
+sysLocation {{ conf.get('sysLocation', 'Unknown (add saltstack pillar)') }}
+sysContact {{ conf.get('sysContact', 'Root <root@localhost> (add saltstack pillar)') }}
 
 # Example output of snmpwalk:
 #   % snmpwalk -v 1 localhost -c public system
@@ -205,13 +206,7 @@ syscontact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pilla
 # If the following option is commented out, snmpd will print each incoming
 # connection, which can be useful for debugging.
 
-{% if conf.get('logconnects') is not none %}
-{%- if conf.get('logconnects') %}
-# dontLogTCPWrappersConnects yes
-{%- else %}
-dontLogTCPWrappersConnects yes
-{%- endif %}
-{% endif %}
+dontLogTCPWrappersConnects {{ 'no' if 'dontLogTCPWrappersConnects' in conf and not conf.get('dontLogTCPWrappersConnects')|to_bool else 'yes' }}
 
 # -----------------------------------------------------------------------------
 
@@ -469,7 +464,7 @@ disk {{ disk }}
 #
 # Example:  (see the script for details)
 #           (commented out here since it requires that you place the
-#           script in the right location. (its not installed by default))
+#           script in the right location. (it's not installed by default))
 
 # pass .1.3.6.1.4.1.2021.255 /bin/sh /usr/local/local/passtest
 
@@ -500,13 +495,13 @@ disk {{ disk }}
 # Version 3 users
 
 {%- for user in conf.get('rousers', '') %}
-rouser {{ user.username }} {{ user.get('securitylevel', 'auth') }} -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.get('authpassphrase', user.passphrase) }} {{ user.get('privproto', 'AES') }} {{ user.get('privpassphrase', user.passphrase) }}
+rouser {{ user.username }} {% if user.get('view') %}{{ user.get('securitylevel', 'auth') }} -V {{ user.view }}{% endif %}
+{% if 'persistentconfig' in snmp %}# createUser string will be added to {{ snmp.persistentconfig }}{% else %}{{ v3_createUser_string(user) }}{% endif %}
 {%- endfor %}
 
 {%- for user in conf.get('rwusers', '') %}
-rwuser {{ user.username }} {{ user.get('securitylevel', 'auth') }} -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.get('authpassphrase', user.passphrase) }} {{ user.get('privproto', 'AES') }} {{ user.get('privpassphrase', user.passphrase) }}
+rwuser {{ user.username }} {% if user.get('view') %}{{ user.get('securitylevel', 'auth') }} -V {{ user.view }}{% endif %}
+{% if 'persistentconfig' in snmp %}# createUser string will be added to {{ snmp.persistentconfig }}{% else %}{{ v3_createUser_string(user) }}{% endif %}
 {%- endfor %}
 
 {% for declaration, values in config.items() %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -3,7 +3,7 @@
 
 ###############################################################################
 #
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -1,7 +1,7 @@
 {% from "snmp/conf.jinja" import conf with context -%}
 {% from "snmp/macros.jinja" import v12c_communities with context -%}
 
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -1,5 +1,6 @@
 {% from "snmp/conf.jinja" import conf with context -%}
-{% from "snmp/macros.jinja" import v12c_communities with context -%}
+{% from "snmp/map.jinja" import snmp with context -%}
+{% from "snmp/macros.jinja" import v12c_communities,v3_createUser_string with context -%}
 
 # {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
@@ -16,16 +17,10 @@
 ##############################################################################
 # System contact information
 #
-sysLocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
-sysContact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
+sysLocation {{ conf.get('sysLocation', 'Unknown (add saltstack pillar)') }}
+sysContact {{ conf.get('sysContact', 'Root <root@localhost> (add saltstack pillar)') }}
 
-{% if conf.get('logconnects') is not none %}
-{%- if conf.get('logconnects') %}
-# dontLogTCPWrappersConnects yes
-{%- else %}
-dontLogTCPWrappersConnects yes
-{%- endif %}
-{% endif %}
+dontLogTCPWrappersConnects {{ 'no' if 'dontLogTCPWrappersConnects' in conf and not conf.get('dontLogTCPWrappersConnects')|to_bool else 'yes' }}
 
 ###############################################################################
 # Access Control
@@ -61,7 +56,7 @@ view {{ entry.name }} {{ entry.type }} {{ entry.oid }} {{ entry.mask if 'mask' i
 
 #       group          context sec.model sec.level prefix read   write  notif
 {%- for entry in conf.get('access', []) %}
-access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read }} {{ entry.write }} {{ entry.notify }}
+access {{ entry.name }} {{ entry.context or '""' }} {{ entry.match }} {{ entry.level }} {{ entry.prefix }} {{ entry.read or 'none' }} {{ entry.write or 'none' }} {{ entry.notify or 'none' }}
 {%- endfor %}
 
 # Version 1/2c users (read only)
@@ -71,14 +66,14 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 
 # Version 3 users (read only)
 {%- for user in conf.get('rousers', []) %}
-rouser {{ user.username }} auth -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
+rouser {{ user.username }} {% if user.get('view') %}{{ user.get('securitylevel', 'auth') }} -V {{ user.view }}{% endif %}
+{% if 'persistentconfig' in snmp  %}# createUser string will be added to {{ snmp.persistentconfig }}{% else %}{{ v3_createUser_string(user) }}{% endif %}
 {%- endfor %}
 
 # Version 3 users (read/write)
 {%- for user in conf.get('rwusers', []) %}
-rwuser {{ user.username }} auth -V {{ user.view }}
-createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passphrase }} {{ user.get('privproto', 'AES') }}
+rwuser {{ user.username }} {% if user.get('view') %}{{ user.get('securitylevel', 'auth') }} -V {{ user.view }}{% endif %}
+{% if 'persistentconfig' in snmp %}# createUser string will be added to {{ snmp.persistentconfig }}{% else %}{{ v3_createUser_string(user) }}{% endif %}
 {%- endfor %}
 
 # Extra settings

--- a/snmp/files/snmpd.default
+++ b/snmp/files/snmpd.default
@@ -1,4 +1,4 @@
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/files/snmpd.options
+++ b/snmp/files/snmpd.options
@@ -1,4 +1,4 @@
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/files/snmptrapd.conf
+++ b/snmp/files/snmptrapd.conf
@@ -1,4 +1,4 @@
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/files/snmptrapd.options
+++ b/snmp/files/snmptrapd.options
@@ -1,4 +1,4 @@
-# {{ salt['pillar.get']('SALT_MANAGED') }}
+# {{ salt['pillar.get']('SALT_MANAGED','This file is managed by salt. Do not edit') }}
 #
 # DO NOT EDIT
 #

--- a/snmp/init.sls
+++ b/snmp/init.sls
@@ -5,11 +5,14 @@
 snmp:
   pkg.installed:
     - name: {{ snmp.pkg }}
-  service.running:
+  service.enabled:
     - name: {{ snmp.service }}
-    - enable: true
     - require:
       - pkg: {{ snmp.pkg }}
+  service.running:
+    - name: {{ snmp.service }}
+    - watch:
+      - file: {{ snmp.config }}
 
 {% if grains['os_family'] == 'Debian' and grains['osmajorrelease'] < 9 %}
 include:

--- a/snmp/init.sls
+++ b/snmp/init.sls
@@ -5,10 +5,13 @@
 snmp:
   pkg.installed:
     - name: {{ snmp.pkg }}
-  service.enabled:
+  service.running:
     - name: {{ snmp.service }}
+    - enable: true
     - require:
       - pkg: {{ snmp.pkg }}
+
+snmp_daemon_start:
   service.running:
     - name: {{ snmp.service }}
     - watch:

--- a/snmp/init.sls
+++ b/snmp/init.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 snmp:

--- a/snmp/macros.jinja
+++ b/snmp/macros.jinja
@@ -2,7 +2,7 @@
 
 {# mode can be either 'ro' or 'rw' #}
 {%- macro v12c_communities(mode, proto='') -%}
-  {% set communities = conf.get(mode+'communities'+proto, []) -%}
+  {% set communities = conf.get(mode~'communities'~proto, []) -%}
   {%- for community in communities %}
     {%- if communities is mapping and communities.get(community, {}) is  mapping %}
       {%- set source = communities.get(community).get('source', '') %}
@@ -15,8 +15,12 @@
       {%- set source = [source] %}
     {%- endif %}
     {%- for src in source -%}
-{{ mode }}community     {{ community }}       {{ src }}{{ ' -V ' + view if view else '' }}
+{{ mode }}community     {{ community }}       {{ src }}{{' -V ' ~ view if view else ''}}
 {%      endfor %}
   {%- endfor -%}
-{% endmacro -%}
+{% endmacro-%}
 
+{%- macro v3_createUser_string(user) -%}
+  {% set seclevel = user.get('securitylevel', 'auth') -%}
+createUser {{ user.username }} {{ user.get('authproto', 'SHA') }} {{ user.authpassphrase }} {{ user.get('privproto', 'AES') }} {% if seclevel == "priv" %}{{ user.privpassphrase }}{% else %}{{ user.get('privpassphrase', '') }}{% endif %}
+{%- endmacro -%}

--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -21,6 +21,7 @@ RedHat:
     pkgutils: net-snmp-utils
     options: /etc/sysconfig/snmpd
     optionstrap: /etc/sysconfig/snmptrapd
+    persistentconfig: /var/lib/net-snmp/snmpd.conf
     sourceoptions: salt://snmp/files/snmpd.options
     sourceoptionstrap: salt://snmp/files/snmptrapd.options
 Debian:
@@ -28,6 +29,7 @@ Debian:
     pkgutils: snmp
     configdefault: /etc/default/snmpd
     sourcedefault: salt://snmp/files/snmpd.default
+    persistentconfig: /var/lib/snmp/snmpd.conf
     snmpdargs: -Lsd -Lf /dev/null -u snmp -g snmp -I -smux,mteTrigger,mteTriggerConf -p /var/run/snmpd.pid
     mibs:
     snmpdrun: "yes"

--- a/snmp/options.sls
+++ b/snmp/options.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:

--- a/snmp/optionstrap.sls
+++ b/snmp/optionstrap.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:

--- a/snmp/trap.sls
+++ b/snmp/trap.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:

--- a/snmp/utils.sls
+++ b/snmp/utils.sls
@@ -2,6 +2,8 @@
 
 {% from "snmp/map.jinja" import snmp with context %}
 
-snmp-utils:
+{% if 'pkgutils' in snmp -%}
+snmp_utils:
   pkg.installed:
     - name: {{ snmp.pkgutils }}
+{% endif -%}

--- a/snmp/utils.sls
+++ b/snmp/utils.sls
@@ -1,3 +1,5 @@
+# vim: ft=sls
+
 {% from "snmp/map.jinja" import snmp with context %}
 
 snmp-utils:

--- a/test/integration/default/controls/config.rb
+++ b/test/integration/default/controls/config.rb
@@ -3,7 +3,7 @@
 control 'snmp.config.file' do
   title 'Verify the configuration file'
 
-  # Overide by platform family
+  # Override by platform family
   config_file, root_group =
     case platform[:family]
     when 'bsd'
@@ -11,14 +11,25 @@ control 'snmp.config.file' do
     else
       %w[/etc/snmp/snmpd.conf root]
     end
+  
+  # Override for persistent config file
+  createUser_str =
+    case platform[:family]
+    when 'debian'
+      'createUser string will be added to /var/lib/snmp/snmpd.conf'
+    when 'redhat'
+      'createUser string will be added to /var/lib/net-snmp/snmpd.conf'
+    else
+      'createUser myv3user SHA myv3password AES v3privpass'
+    end
 
   describe file(config_file) do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into root_group }
     its('mode') { should cmp '0644' }
-    its('content') { should include 'syslocation Right Here' }
-    its('content') { should include 'syscontact System Admin' }
+    its('content') { should include 'sysLocation Right Here' }
+    its('content') { should include 'sysContact System Admin' }
     its('content') { should include 'dontLogTCPWrappersConnects yes' }
     its('content') { should include 'view all included .1 80' }
     its('content') { should include 'rocommunity     public       localhost' }
@@ -27,7 +38,7 @@ control 'snmp.config.file' do
     its('content') { should include 'rwcommunity     private       192.168.1.0/24' }
     its('content') { should include 'rouser myv3user auth -V all' }
     its('content') do
-      should include 'createUser myv3user SHA myv3password AES v3privpass'
+      should include createUser_str
     end
   end
 end

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -3,9 +3,9 @@
 ---
 snmp:
   conf:
-    location: 'Right Here'
-    syscontact: 'System Admin'
-    logconnects: false
+    sysLocation: 'Right Here'
+    sysContact: 'System Admin'
+    dontLogTCPWrappersConnects: true
     views:
       - name: all
         type: included


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes, there are a few breaking changes.

1. `logconnect` has been changed to `dontLogTCPWrappersConnects` which identically matches the snmpd.conf option (instead of forcing a formula specific value). This also corrects a slightly less than intuitive boolean usage.
2. `syscontact` changed to `sysContact` to also match the snmpd.conf option.
3. `location` changed to `sysLocation` to also match the snmpd.conf option.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

- First and foremost, this addresses the SNMP user/pass being dumped into snmpd.conf in plaintext. 
  - The specific workflow for Deb/RHEL systems is test SNMP access with credentials -> (on fail) stop snmpd -> add createUser string to the correct config file (/var/lib/____/snmpd.conf) -> start snmpd back up. Doing so will cause the credentials to be "consumed", converted into something no longer human readable. 
- Second, it standardizes a few of the options and moves closer to the Saltstack formula recommendation of "_sane default values_".

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

None, files `test/integration/default/controls/config.rb` and `test/salt/pillar/default.sls` were updated to all turnkey testing.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

CentOS 7 3003.3 and 3004.0 (both py3) would fail to start up SSH. Skipping those

CentOS 8 3003.3 py3 
```
-----> Verifying <default-centos-8-3003-3-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:61297

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/net-snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package net-snmp is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running
```

CentOS 8 3004.0 py3
```
-----> Verifying <default-centos-8-3004-0-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:60780

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/net-snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package net-snmp is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running
```

Debian 9 3003.3 py3
```
-----> Verifying <default-debian-9-3003-3-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:61403

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package snmpd is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running

```

Debian 9 3004.0 py3
```
-----> Verifying <default-debian-9-3004-0-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:60961

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package snmpd is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running
```

Debian 10 3003.3 py3
```
-----> Verifying <default-debian-10-3003-3-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:61477

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package snmpd is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running
```

Debian 10 3004.0 py3
```
-----> Verifying <default-debian-10-3004-0-py3>...
       Loaded default

Profile: snmp formula (default)
Version: (not specified)
Target:  ssh://kitchen@localhost:60885

  ✔  snmp.config.file: Verify the configuration file
     ✔  File /etc/snmp/snmpd.conf is expected to be file
     ✔  File /etc/snmp/snmpd.conf is expected to be owned by "root"
     ✔  File /etc/snmp/snmpd.conf is expected to be grouped into "root"
     ✔  File /etc/snmp/snmpd.conf mode is expected to cmp == "0644"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysLocation Right Here"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "sysContact System Admin"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "dontLogTCPWrappersConnects yes"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "view all included .1 80"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       localhost"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.0.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rocommunity     public       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rwcommunity     private       192.168.1.0/24"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "rouser myv3user auth -V all"
     ✔  File /etc/snmp/snmpd.conf content is expected to include "createUser string will be added to /var/lib/snmp/snmpd.conf"
  ✔  snmp.package.install: The required package should be installed
     ✔  System Package snmpd is expected to be installed
  ✔  snmp.service.running: The service should be installed, enabled and running
     ✔  Service snmpd is expected to be installed
     ✔  Service snmpd is expected to be enabled
     ✔  Service snmpd is expected to be running
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


